### PR TITLE
Avoid ImportError when GeoIP is missing

### DIFF
--- a/stores/dashboard/forms.py
+++ b/stores/dashboard/forms.py
@@ -2,7 +2,6 @@ from django import forms
 from django.db.models import get_model
 from django.contrib.gis.forms import fields
 from django.utils.translation import ugettext_lazy as _
-
 from django.contrib.gis.geoip import HAS_GEOIP
 
 
@@ -27,7 +26,9 @@ class StoreForm(forms.ModelForm):
             self.initial['location'] = instance.location.geojson
         elif HAS_GEOIP:
             from django.contrib.gis.geoip import GeoIP
-            self.initial['location'] = GeoIP().geos(current_ip).geojson
+            point = GeoIP().geos(current_ip)
+            if point:
+                self.initial['location'] = point.geojson
 
     class Meta:
         model = get_model('stores', 'Store')


### PR DESCRIPTION
Adjust the import of GeoIP to first check whether it is available.  It wasn't
on my Mac and so I was getting an ImportError.

I'm not 100% sure this is the right way of handling this.
