### PR TITLE
Add migration dependencies

### DIFF
--- a/stores/migrations/0001_initial.py
+++ b/stores/migrations/0001_initial.py
@@ -7,6 +7,11 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ("address", "0001_initial"),
+        ("catalogue", "0001_initial"),
+    )
+
     def forwards(self, orm):
         # Adding model 'StoreAddress'
         db.create_table('stores_storeaddress', (


### PR DESCRIPTION
Before the stores migration can run, both the address.Country and 
catalogue.Product tables must be created so the foreign keys have something
to link against.
