### PR TITLE
Hitting enter in location input of dashboard page submits page

### DIFF
--- a/stores/static/stores/js/dashboard.js
+++ b/stores/static/stores/js/dashboard.js
@@ -105,6 +105,9 @@ stores.dashboard = {
 
     updateToBestMatch: function(input, marker) {
         var query = input.val();
+        if(!query) {
+            return;
+        }
         stores.dashboard.autocomplete_serv.getQueryPredictions(
             {'input': query},
             function(results, status) {


### PR DESCRIPTION
It looks like it should search for the entered query, not submit the form. 

![image](https://f.cloud.github.com/assets/80975/102686/42c3158a-6935-11e2-9891-df42661ab51d.png)

I'm not sure on exactly the right thing to do here.  I think we may need some JS to catch the event to avoid submitting the form.
