### PR TITLE
Improve store opening hours UX

### DIFF
--- a/stores/dashboard/forms.py
+++ b/stores/dashboard/forms.py
@@ -1,8 +1,12 @@
 from django import forms
+from django.forms import models as modelforms
 from django.db.models import Q, get_model
 from django.contrib.gis.forms import fields
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.gis.geoip import HAS_GEOIP
+
+OpeningPeriod = get_model('stores', 'OpeningPeriod')
+assert OpeningPeriod
 
 
 class StoreAddressForm(forms.ModelForm):
@@ -14,6 +18,13 @@ class StoreAddressForm(forms.ModelForm):
 
 class StoreForm(forms.ModelForm):
     location = fields.GeometryField(widget=forms.HiddenInput())
+
+    class Meta:
+        model = get_model('stores', 'Store')
+        exclude = ('slug', 'opening_periods', )
+        widgets = {
+            'description': forms.Textarea(attrs={'cols': 40, 'rows': 10}),
+        }
 
     def __init__(self, *args, **kwargs):
         current_ip = kwargs.pop('current_ip', None)
@@ -36,13 +47,6 @@ class StoreForm(forms.ModelForm):
             return None
         return ref
 
-    class Meta:
-        model = get_model('stores', 'Store')
-        exclude = ('slug',)
-        widgets = {
-            'description': forms.Textarea(attrs={'cols': 40, 'rows': 10}),
-        }
-
 
 class OpeningPeriodForm(forms.ModelForm):
 
@@ -50,10 +54,13 @@ class OpeningPeriodForm(forms.ModelForm):
         super(OpeningPeriodForm, self).__init__(*args, **kwargs)
         time_input = ['%H:%M', '%H', '%I:%M%p', '%I%p', '%I:%M %p', '%I %p']
         self.fields['start'].input_formats = time_input
+        self.fields['start'].required = False
         self.fields['end'].input_formats = time_input
+        self.fields['end'].required = False
 
     class Meta:
-        model = get_model('stores', 'OpeningPeriod')
+        model = OpeningPeriod
+        fields = ('start', 'end', )
         widgets = {
             'name': forms.TextInput(
                 attrs={'placeholder': _("e.g. Christmas")}
@@ -67,6 +74,11 @@ class OpeningPeriodForm(forms.ModelForm):
                 attrs={'placeholder': _("e.g. 5 PM, 18:30, etc.")}
             ),
         }
+
+    def clean_delete(self):
+        data = self.cleaned_data
+        if not data['start'] and not data['end']:
+            return True
 
  
 class DashboardStoreSearchForm(forms.Form):
@@ -86,3 +98,100 @@ class DashboardStoreSearchForm(forms.Form):
             if value:
                 qs = getattr(self, 'apply_%s_filter' % key)(qs, value)
         return qs
+
+
+class IsOpenForm(forms.Form):
+    open = forms.BooleanField(label=_('Open'), required=False)
+
+    def __nonzero__(self):
+        self.is_valid()
+        return self.cleaned_data['open']
+
+
+class OpeningPeriodFormset(modelforms.BaseInlineFormSet):
+    extra = 10
+    can_order = False
+    can_delete = True
+    max_num = 30 # Reasonably safe number of maximum period intervals per day
+    absolute_max = 30
+    fk = [f for f in OpeningPeriod._meta.fields if f.name == 'store'][0]
+    model = OpeningPeriod
+
+    def __init__(self, weekday, data, instance):
+        self.weekday = weekday
+        if instance:
+            queryset = instance.opening_periods.all().filter(weekday=weekday)
+        else:
+            queryset = OpeningPeriod.objects.none()
+        prefix = 'day-%d' % weekday
+
+        self.openform = IsOpenForm(data=data or None, prefix=prefix, initial={
+            'open': len(queryset) > 0
+        })
+
+        self.open = self.openform['open']
+
+        super(OpeningPeriodFormset, self).__init__(data=data, instance=instance,
+                                                   prefix=prefix,
+                                                   queryset=queryset)
+
+    def get_weekday_display(self):
+        return unicode(OpeningPeriod.WEEK_DAYS[self.weekday])
+
+    def form(self, *args, **kwargs):
+         form = OpeningPeriodForm(*args, **kwargs)
+         form.instance.weekday = self.weekday
+         form.instance.store = self.instance
+         return form
+
+    def is_valid(self):
+        return super(OpeningPeriodFormset, self).is_valid()
+
+    def save(self, *args, **kwargs):
+        if not self.openform:
+            for form in self:
+                if form.instance.pk:
+                    form.instance.delete()
+        else:
+            return super(OpeningPeriodFormset, self).save(*args, **kwargs)
+
+
+class OpeningHoursFormset(object):
+    def __init__(self, data, instance):
+        self.data = data or None
+        self.instance = instance
+        self.forms = [self.construct_sub_formset(weekday) for weekday in
+            OpeningPeriod.WEEK_DAYS
+        ]
+
+    def __iter__(self):
+        return iter(self.forms)
+
+    def __getitem__(self, key):
+        return self.forms[key]
+
+    def construct_sub_formset(self, weekday):
+        return OpeningPeriodFormset(
+            weekday,
+            self.data or None,
+            self.instance,
+        )
+
+    def is_valid(self):
+        return all([form.is_valid() for form in self.forms])
+
+    def save(self):
+        for form in self:
+            form.save()
+
+
+class OpeningHoursInline(object):
+    def __init__(self, model, request, instance):
+        self.data = request.POST
+        self.instance = instance
+
+    def construct_formset(self):
+        return OpeningHoursFormset(
+            self.data or None,
+            self.instance,
+        )

--- a/stores/dashboard/views.py
+++ b/stores/dashboard/views.py
@@ -51,8 +51,10 @@ class OpeningPeriodInline(InlineFormSet):
     form_class = forms.OpeningPeriodForm
 
 
+from stores.dashboard.forms import OpeningHoursInline
 class StoreEditMixin(object):
-    inlines = [OpeningPeriodInline, StoreAddressInline]
+    #inlines = [OpeningPeriodInline, StoreAddressInline]
+    inlines = [OpeningHoursInline, StoreAddressInline]
 
     def get_form_kwargs(self):
         kwargs = super(StoreEditMixin, self).get_form_kwargs()

--- a/stores/static/stores/css/stores.css
+++ b/stores/static/stores/css/stores.css
@@ -99,6 +99,7 @@
 }
 .stores-list .sub-header .distance {
   color: #aaa;
+  font-size: 18px;
 }
 .stores-list a.email {
   width: 90%;
@@ -230,4 +231,7 @@ ul.wysihtml5-toolbar > li {
 #opening_hours .line-divide {
   padding: 20px 0;
   border-bottom: 1px solid #eee;
+}
+#opening_hours_form .hour-input input[type=text] {
+  width: 100px;
 }

--- a/stores/static/stores/js/dashboard.js
+++ b/stores/static/stores/js/dashboard.js
@@ -5,8 +5,8 @@ stores.dashboard = {
     defaultLat: 144.9661415816081,
 
     getLatLngFromGeoJSON: function (data) {
-    	var point = null;
-    	try {
+        var point = null;
+        try {
             point = jQuery.parseJSON(data);
         } catch (e) {}
 
@@ -104,6 +104,8 @@ stores.dashboard = {
                 stores.dashboard.updateToBestMatch(input, marker);
             }
         });
+
+        stores.dashboard.openingHoursForm();
     },
 
     updateToBestMatch: function(input, marker) {
@@ -162,6 +164,22 @@ stores.dashboard = {
                 }
             }
             );
+    },
+
+    openingHoursForm: function(){
+        function isOpenCallback() {
+            var isopen = $(this).prop('checked');
+            var inputs = $(this).closest('.weekday-block').find('input[type=text],button');
+            inputs.prop('disabled', !isopen);
+        }
+        $('#opening_hours_form input[name$=open]').each(isOpenCallback)
+                                                   .click(isOpenCallback);
+
+        $('#opening_hours_form button.add-more').click(function(e){
+            e.preventDefault();
+            $(this).closest('.weekday-block').find('.hour-input.hide').first().removeClass('hide');
+            return false;
+        });
     }
 };
 

--- a/stores/static/stores/less/stores.less
+++ b/stores/static/stores/less/stores.less
@@ -263,3 +263,7 @@ ul.wysihtml5-toolbar > li {
   padding: 20px 0;
   border-bottom: 1px solid #eee;
 }
+
+#opening_hours_form .hour-input input[type=text] {
+    width: 100px;
+}

--- a/stores/templates/stores/dashboard/store_update.html
+++ b/stores/templates/stores/dashboard/store_update.html
@@ -100,17 +100,75 @@
     <div class="table-header">
         <h3>{% trans "Opening hours" %}</h3>
     </div>
-    <div class="well">
-        {# use the first formset which is the opening times #}
-        {% with formset=inlines.0 %}
-        <div class="well well-blank">
-            {{ formset.management_form }}
-            {% for form in formset %}
-            <div class='row-fluid line-divide' style="margin-bottom: 1em;">
-                {% for field in form %}
-                    {% include "partials/field_inline.html" %}
-                {% endfor %}
 
+    <div class="well form-horizontal" id="opening_hours_form">
+        {# use the first formset which is the opening times #}
+        {% with workhours=inlines.0 %}
+            {{ formset.management_form }}
+            {% for formset in workhours %}
+            <div class="weekday-block well">
+                <div class="span2">
+                  <label>{{ formset.get_weekday_display }}</label>
+                </div>
+
+                <div class="span1">
+                    <label>{{ formset.open.label }}</label>
+                    {{ formset.open }}
+                </div>
+
+                <div class="span8">
+
+                  <div class="row"></div>
+
+                  <div class="row">
+                    <div class="span2">
+                      {{ formset.0.start.label_tag }}
+                    </div>
+                    <div class="span2">
+                      {{ formset.0.end.label_tag }}
+                    </div>
+                  </div>
+
+                  {% for form in formset %}
+                  <div class="row hour-input{% if not forloop.first and not form.start.value and not form.end.value %} hide{% endif %}"
+                      style="margin-bottom: 1em">
+
+                    <div class="span2">
+                    {{ form.start }}
+                    </div>
+                    <div class="span2">
+                    {{ form.end }}
+                    </div>
+
+                    {{ form.id }}
+
+                    {% if form.errors %}
+                    <div class="span4">
+                      <div class="alert alert-error">
+                      {% for field in form %}
+                        {% if field.errors %}
+                          {{ field.label }}:
+                          {% for err in field.errors %}{{ err }}{% endfor %}
+                          <br />
+                        {% endif %}
+                      {% endfor %}
+                      </div>
+                    </div>
+                    {% endif %}
+                  </div>
+                  {% endfor %}
+
+                  <div class="row">
+                    <div class="span2">
+                      <button class="btn add-more">+</button>
+                    </div>
+                  </div>
+
+                  <div class="row"></div>
+
+                </div>
+
+                {{ formset.management_form }}
             </div>
             {% endfor %}
         {% endwith %}


### PR DESCRIPTION
- [x] Fix issue where things like '9am - 1pm' are entered as a time.  Needs some form validation.
- [ ] Improve UX of opening hours dashboard.  Fix the weekdays and allow multiple time periods per day to be entered. 

Need to ensure that when opening hours are rendered, they group at the day level and generally look sensible.
