### PR TITLE
Add option to limit search result by distance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,16 @@ Settings
 
 * ``STORES_GEODETIC_SRID`` (default: ``4326``).
 
+* ``STORES_MAX_SEARCH_DISTANCE`` (default: None). This filters stores
+  in queries by distance. Units can be set using distance object::
+
+    from django.contrib.gis.measure import D
+    # Maximal distance of 150 miles
+    STORES_MAX_SEARCH_DISTANCE = D(mi=150)
+    # Maximal distance of 150 kilometers
+    STORES_MAX_SEARCH_DISTANCE = D(km=150)
+
+
 Contributing
 ------------
 

--- a/stores/templates/stores/index.html
+++ b/stores/templates/stores/index.html
@@ -73,45 +73,49 @@
         </div>
 
         <div class="span9">
-            <div class='row-fluid'>
-                <map class='span12'>
-                    <div id='store-map' style="width: 100%; height: 380px;"></div>
-                </map>
-            </div>
+            {% if store_list %}
+                <div class='row-fluid'>
+                    <map class='span12'>
+                        <div id='store-map' style="width: 100%; height: 380px;"></div>
+                    </map>
+                </div>
 
-            {% for store in store_list %}
-            <div class="stores-list">
-                <div class="row-fluid">
-                    <div class="span12">
-                        <div class="sub-header">
-                            <h4>{{ store.name }}
-                            {% if store.distance %}
-                                <span class="distance">{{ store.distance.km|floatformat:2 }} km</span>
-                            {% endif %}
-                            <a href="{% url 'stores:detail' store.slug store.pk %}" class="btn pull-right">{% trans "View store details" %}</a></h4>
+                {% for store in store_list %}
+                <div class="stores-list">
+                    <div class="row-fluid">
+                        <div class="span12">
+                            <div class="sub-header">
+                                <h4>{{ store.name }}
+                                {% if store.distance %}
+                                    <span class="distance">{{ store.distance.km|floatformat:2 }} km</span>
+                                {% endif %}
+                                <a href="{% url 'stores:detail' store.slug store.pk %}" class="btn pull-right">{% trans "View store details" %}</a></h4>
+                            </div>
                         </div>
                     </div>
+                    <div class="row-fluid">
+                        <div class="span4">
+                            {% thumbnail store.image "400x400" as im %}
+                            <a href="{{ store.get_absolute_url }}"><img alt="{{ store.name }}" src="{{ im.url }}" width="{{ im.width}}" height="{{ im.height }}" /></a>
+                            {% endthumbnail %}
+                        </div>
+
+                        <div class="span4 store-address-contact">
+                            {% include "stores/partials/store_address.html" %}
+                            {% include "stores/partials/store_contact.html" %}
+                            <br/>
+                        </div>
+
+                        <div class="span4">
+                            {% include "stores/partials/store_opening_periods.html" %}
+                        </div>
+
+                    </div>
                 </div>
-                <div class="row-fluid">
-                    <div class="span4">
-                        {% thumbnail store.image "400x400" as im %}
-                        <a href="{{ store.get_absolute_url }}"><img alt="{{ store.name }}" src="{{ im.url }}" width="{{ im.width}}" height="{{ im.height }}" /></a>
-                        {% endthumbnail %}
-                    </div>
-
-                    <div class="span4 store-address-contact">
-                        {% include "stores/partials/store_address.html" %}
-                        {% include "stores/partials/store_contact.html" %}
-                        <br/>
-                    </div>
-
-                    <div class="span4">
-                        {% include "stores/partials/store_opening_periods.html" %}
-                    </div>
-
-                </div>
-            </div>
-            {% endfor %}
+                {% endfor %}
+            {% else %}
+                <p>{% trans "No stores found in the area." %}</p>
+            {% endif %}
         </section>
         {% else %}
         <p>{% trans "No store data available." %}</p>


### PR DESCRIPTION
If you have many stores, e.g. all over US and user searches for New York,
allow the website to show only stores within a certain distance, e.g. in 50
miles radius of New York.

Feature is turned off by default (the current stores setting) and can be turn
on by setting STORES_MAX_SEARCH_DISTANCE for central limit or can be modified
by overriding get_max_distance() for dynamic values, e.g. changing the
distance for certain queries.
