### PR TITLE
replace djangos slugifier with oscars slugifier

### DIFF
--- a/stores/abstract_models.py
+++ b/stores/abstract_models.py
@@ -2,10 +2,10 @@ from django.db import models
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
-from django.template.defaultfilters import slugify
 from django.contrib.gis.db.models import PointField
 from django.contrib.gis.db.models import GeoManager
 
+from oscar.core.utils import slugify
 from oscar.apps.address.abstract_models import AbstractAddress
 
 from stores.managers import StoreManager


### PR DESCRIPTION
Django's slugifier cannot handle non-ascii characters see [issue #982](https://github.com/tangentlabs/django-oscar/issues/982) in django-oscar repo.
