### PR TITLE
django 1.10 fixes

### DIFF
--- a/stores/app.py
+++ b/stores/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 
@@ -12,12 +12,12 @@ class StoresApplication(Application):
 
     def get_urls(self):
         urlpatterns = super(StoresApplication, self).get_urls()
-        urlpatterns += patterns('',
+        urlpatterns += ['',
             url(r'^$', self.list_view.as_view(),
                 name='index'),
             url(r'^(?P<dummyslug>[\w-]+)/(?P<pk>\d+)/$',
                 self.detail_view.as_view(), name='detail'),
-        )
+        ]
         return self.post_process_urls(urlpatterns)
 
 

--- a/stores/app.py
+++ b/stores/app.py
@@ -11,8 +11,7 @@ class StoresApplication(Application):
     detail_view = views.StoreDetailView
 
     def get_urls(self):
-        urlpatterns = super(StoresApplication, self).get_urls()
-        urlpatterns += ['',
+        urlpatterns = [
             url(r'^$', self.list_view.as_view(),
                 name='index'),
             url(r'^(?P<dummyslug>[\w-]+)/(?P<pk>\d+)/$',

--- a/stores/dashboard/forms.py
+++ b/stores/dashboard/forms.py
@@ -134,7 +134,7 @@ class OpeningPeriodFormset(modelforms.BaseInlineFormSet):
     min_num = 0
     max_num = 30  # Reasonably safe number of maximum period intervals per day
     absolute_max = 30
-    fk = [f for f in OpeningPeriod._meta.fields if f.name == 'store'][0]
+    fk = [f for f in OpeningPeriod._meta.get_fields() if f.name == 'store'][0]
     model = OpeningPeriod
     validate_min = True
     validate_max = True


### PR DESCRIPTION
stop misusing get_urls() for getting list
use get_fields() instead of fields