### PR TITLE
Add support for Django 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,10 +100,12 @@ then add ``stores`` to ``INSTALLED_APPS``.  Now update your root ``urls.py``:
         url(r'^', include(apps.get_app_config('oscar').urls[0])),
 
         # adds URLs for the dashboard store manager
-        url(r'^dashboard/stores/', apps.get_app_config('stores_dashboard').urls),
+        url(r'^dashboard/stores/', apps.get_app_config('stores_dashboard').urls),  # Django 1
+        # path('dashboard/stores/', include('stores.dashboard.urls', namespace="stores-dashboard")),  # Django 2
 
         # adds URLs for overview and detail pages
-        url(r'^stores/', apps.get_app_config('stores').urls),
+        url(r'^stores/', apps.get_app_config('stores').urls),  # Django 1
+        # path('stores/', include('stores.urls', namespace="stores")),  # Django 2
 
         # adds internationalization URLs
         url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name="javascript-catalogue"),
@@ -112,7 +114,7 @@ then add ``stores`` to ``INSTALLED_APPS``.  Now update your root ``urls.py``:
 You also need to download the `GeoIP data files`_ and set ``GEOIP_PATH`` to point to the
 appropriate directory.
 
-.. _`GeoIP data files`: https://docs.djangoproject.com/en/stable/ref/contrib/gis/geoip/
+.. _`GeoIP data files`: https://docs.djangoproject.com/en/stable/ref/contrib/gis/geoip2/
 
 Settings
 --------

--- a/stores/dashboard/urls.py
+++ b/stores/dashboard/urls.py
@@ -1,0 +1,38 @@
+from django.conf.urls import url
+
+from oscar.core.loading import get_class
+
+app_name = "stores_dashboard"
+
+store_list_view = get_class("stores.dashboard.views", "StoreListView")
+store_create_view = get_class("stores.dashboard.views", "StoreCreateView")
+store_update_view = get_class("stores.dashboard.views", "StoreUpdateView")
+store_delete_view = get_class("stores.dashboard.views", "StoreDeleteView")
+
+store_group_list_view = get_class("stores.dashboard.views", "StoreGroupListView")
+store_group_create_view = get_class("stores.dashboard.views", "StoreGroupCreateView")
+store_group_update_view = get_class("stores.dashboard.views", "StoreGroupUpdateView")
+store_group_delete_view = get_class("stores.dashboard.views", "StoreGroupDeleteView")
+
+urlpatterns = [
+    url(r"^$", store_list_view.as_view(), name="store-list"),
+    url(r"^create/$", store_create_view.as_view(), name="store-create"),
+    url(r"^update/(?P<pk>[\d]+)/$", store_update_view.as_view(), name="store-update"),
+    url(r"^delete/(?P<pk>[\d]+)/$", store_delete_view.as_view(), name="store-delete"),
+    url(r"^groups/$", store_group_list_view.as_view(), name="store-group-list"),
+    url(
+        r"^groups/create/$",
+        store_group_create_view.as_view(),
+        name="store-group-create",
+    ),
+    url(
+        r"^groups/update/(?P<pk>[\d]+)/$",
+        store_group_update_view.as_view(),
+        name="store-group-update",
+    ),
+    url(
+        r"^groups/delete/(?P<pk>[\d]+)/$",
+        store_group_delete_view.as_view(),
+        name="store-group-delete",
+    ),
+]

--- a/stores/urls.py
+++ b/stores/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+from django.conf.urls import url
+
+from oscar.core.loading import get_class
+
+list_view = get_class("stores.views", "StoreListView")
+detail_view = get_class("stores.views", "StoreDetailView")
+
+app_name = "stores"
+
+urlpatterns = [
+    path("", list_view.as_view(), name="index"),
+    url(r"^(?P<dummyslug>[\w-]+)/(?P<pk>\d+)/$", detail_view.as_view(), name="detail"),
+]


### PR DESCRIPTION
Added urls.py for stores and dashboard, and updated README.rst
to explain how to use stores with Django 1 and 2.

Closes https://github.com/django-oscar/django-oscar-stores/issues/120