### PR TITLE
Add support for Django 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        django-version: [2.2, 3.1]
+        django-version: [2.2, 3.1, 3.2]
     services:
       postgres:
         image: postgis/postgis:10-2.5

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: Unix',

--- a/stores/services/geocode.py
+++ b/stores/services/geocode.py
@@ -44,7 +44,7 @@ def get_response_exception(status):
     return code_to_exception_map.get(status, UnknownError)
 
 
-class BaseGeoCodeService(object):
+class BaseGeoCodeService:
     """
     Base class to geocode a search query.
     """

--- a/stores/views.py
+++ b/stores/views.py
@@ -8,7 +8,7 @@ StoreSearchForm = get_class('stores.forms', 'StoreSearchForm')
 Store = get_model('stores', 'store')
 
 
-class MapsContextMixin(object):
+class MapsContextMixin:
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39}-django{22,31}
+envlist = py{37,38,39}-django{22,31,32}
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
@@ -7,6 +7,7 @@ deps =
     -r{toxinidir}/requirements.txt
     django22: django>=2.2,<2.3
     django31: django>=3.1,<3.2
+    django32: django>=3.2,<3.3
 
 [testenv:lint]
 basepython = python3.7


### PR DESCRIPTION
Generate OpeningPeriodFormset using inlineformset_factory instead of a manually defined class.