### PR TITLE
Make miscellaneous fixes

### DIFF
--- a/stores/dashboard/forms.py
+++ b/stores/dashboard/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib.gis.forms import fields
 from django.db.models import Q
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from oscar.core.loading import get_class, get_model
 
@@ -51,9 +51,6 @@ class OpeningPeriodForm(forms.ModelForm):
         model = OpeningPeriod
         fields = ['start', 'end']
         widgets = {
-            'name': forms.TextInput(
-                attrs={'placeholder': _("e.g. Christmas")}
-            ),
             'start': forms.TimeInput(
                 format='%H:%M',
                 attrs={'placeholder': _("e.g. 9 AM, 11:30, etc.")}
@@ -71,9 +68,7 @@ class OpeningPeriodForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         time_input = ['%H:%M', '%H', '%I:%M%p', '%I%p', '%I:%M %p', '%I %p']
         self.fields['start'].input_formats = time_input
-        self.fields['start'].required = False
         self.fields['end'].input_formats = time_input
-        self.fields['end'].required = False
 
     def save(self, commit=True):
         self.instance.store = self.store
@@ -147,7 +142,7 @@ class OpeningPeriodFormset(BaseOpeningPeriodFormset):
         super().__init__(data=data, instance=instance, prefix=prefix, queryset=queryset)
 
     def get_weekday_display(self):
-        return force_text(OpeningPeriod.WEEK_DAYS[self.weekday])
+        return force_str(OpeningPeriod.WEEK_DAYS[self.weekday])
 
     def get_form_kwargs(self, index):
         return {

--- a/stores/templates/stores/dashboard/messages/store_saved.html
+++ b/stores/templates/stores/dashboard/messages/store_saved.html
@@ -2,5 +2,5 @@
 {% blocktrans with name=store.name %}
 <strong>{{ name }}</strong> store saved.
 {% endblocktrans %}
-<a href="{{ store.get_absolute_url }}" class="btn btn-success btn-sm">{% trans "View on site" %}</a>
-<a href="{% url 'stores-dashboard:store-update' store.pk %}" class="btn btn-warning btn-sm">{% trans "Edit again" %}</a>
+<a href="{{ store.get_absolute_url }}" class="btn btn-success">{% trans "View on site" %}</a>
+<a href="{% url 'stores-dashboard:store-update' store.pk %}" class="btn btn-warning">{% trans "Edit again" %}</a>

--- a/stores/templates/stores/dashboard/store_delete.html
+++ b/stores/templates/stores/dashboard/store_delete.html
@@ -24,9 +24,9 @@
             {% blocktrans with store_name=object.name %}
             <p>Delete store <strong>{{ store_name }}</strong> - are you sure?</p>
             {% endblocktrans %}
-            <button type="submit" class="btn btn-lg btn-danger">{% trans "Delete" %}</button>
+            <button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
             {% trans "or" %}
-            <a href="{% url 'stores-dashboard:store-group-list' %}">{% trans "cancel" %}</a>
+            <a href="{% url 'stores-dashboard:store-list' %}">{% trans "cancel" %}</a>
         </div>
     </form>
 </div>

--- a/stores/templates/stores/dashboard/store_group_delete.html
+++ b/stores/templates/stores/dashboard/store_group_delete.html
@@ -28,7 +28,7 @@
             {% blocktrans with group_name=object.name %}
             <p>Delete store group <strong>{{ group_name }}</strong> - are you sure?</p>
             {% endblocktrans %}
-            <button type="submit" class="btn btn-lg btn-danger">{% trans "Delete" %}</button>
+            <button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
             {% trans "or" %}
             <a href="{% url 'stores-dashboard:store-group-list' %}">{% trans "cancel" %}</a>
         </div>

--- a/stores/templates/stores/dashboard/store_group_list.html
+++ b/stores/templates/stores/dashboard/store_group_list.html
@@ -17,16 +17,12 @@
 
 {% block header %}
 <div class="page-header">
-    <a href="{% url 'stores-dashboard:store-group-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus"></i> {% trans "Create new store group" %}</a>
+    <a href="{% url 'stores-dashboard:store-group-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new store group" %}</a>
     <h1>{% trans "Store Groups" %}</h1>
 </div>
 {% endblock header %}
 
 {% block dashboard_content %}
-
-<div class="sub-header">
-    <h2>{{ queryset_description }}</h2>
-</div>
 
 {% if group_list.all|length %}
 <form method="post" class="order_table">

--- a/stores/templates/stores/dashboard/store_group_update.html
+++ b/stores/templates/stores/dashboard/store_group_update.html
@@ -30,11 +30,11 @@
     <div class="table-header">
         <h3>{% trans "Store Group Details" %}</h3>
     </div>
-    <div class="card card-body">
+    <div class="card card-body bg-light">
         {% include 'oscar/dashboard/partials/form_fields.html' %}
 
         <div class="form-actions">
-            <button class="btn btn-primary btn-lg" type="submit">{% trans "Save store group" %}</button>
+            <button class="btn btn-primary" type="submit">{% trans "Save store group" %}</button>
             {% trans "or" %}
             <a href="{% url 'stores-dashboard:store-group-list' %}">{% trans "cancel" %}</a>
         </div>

--- a/stores/templates/stores/dashboard/store_list.html
+++ b/stores/templates/stores/dashboard/store_list.html
@@ -23,7 +23,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'stores-dashboard:store-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus"></i> {% trans "Create new store" %}</a>
+        <a href="{% url 'stores-dashboard:store-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new store" %}</a>
         <h1>{% trans "Store Management" %}</h1>
     </div>
 {% endblock header %}
@@ -64,31 +64,31 @@
                 {% for store in store_list %}
                     <tr>
                         <th><a href="{% url 'stores-dashboard:store-update' store.pk %}">{{ store.name }}</a></th>
-                        <td>{{ store.address.street }}</td>
+                        <td>{{ store.address.street|linebreaksbr }}</td>
                         <td>{{ store.address.line4 }}</td>
                         <td>{{ store.address.postcode }}</td>
                         <td>{{ store.address.state|default:"-" }}</td>
                         <td>{{ store.address.country }}</td>
                         <td>
                             {% if store.is_pickup_store %}
-                                <span class="label label-success">{% trans "Yes" %}</span>
+                                <span class="badge badge-success">{% trans "Yes" %}</span>
                             {% else %}
-                                <span class="label label-danger">{% trans "No" %}</span>
+                                <span class="badge badge-danger">{% trans "No" %}</span>
                             {% endif %}
                         </td>
                         <td>
                             {% if store.is_active %}
-                                <span class="label label-success">{% trans "Active" %}</span>
+                                <span class="badge badge-success">{% trans "Active" %}</span>
                             {% else %}
-                                <span class="label label-danger">{% trans "Inactive" %}</span>
+                                <span class="badge badge-danger">{% trans "Inactive" %}</span>
                             {% endif %}
                         </td>
                         <td>
                             {% block row_actions %}
                             <div class="btn-group">
                                 <a class="btn btn-info" href="{% url 'stores:detail' store.slug store.id %}">{% trans "View on site" %}</a>
-                                <button class="btn btn-info dropdown-toggle" data-toggle="dropdown"></button>
-                                 <div class="dropdown-menu">
+                                <button type="button" class="btn btn-info dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown"></button>
+                                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
                                     <a class="dropdown-item" href="{% url 'stores-dashboard:store-update' store.id %}">{% trans "Edit" %}</a>
                                     <a class="dropdown-item" href="{% url 'stores-dashboard:store-delete' store.id %}">{% trans "Delete" %}</a>
                                 </div>

--- a/stores/templates/stores/dashboard/store_update.html
+++ b/stores/templates/stores/dashboard/store_update.html
@@ -1,6 +1,8 @@
 {% extends 'oscar/dashboard/layout.html' %}
 {% load i18n static %}
 
+{% block body_class %}stores{% endblock %}
+
 {% block title %}
 {{ title }} | {{ block.super }}
 {% endblock %}
@@ -38,7 +40,7 @@
     <div class="table-header">
         <h3>{% trans "Store details" %}</h3>
     </div>
-    <div class="card card-body">
+    <div class="card card-body bg-light">
         {% block store_details_fields %}
         {% include "oscar/dashboard/partials/form_field.html" with field=form.name %}
         {% include "oscar/dashboard/partials/form_field.html" with field=form.description %}
@@ -53,7 +55,7 @@
     <div class="table-header">
         <h3>{% trans "Contact details" %}</h3>
     </div>
-    <div class="card card-body">
+    <div class="card card-body bg-light">
         {% block contact_details_fields %}
         {% include "oscar/dashboard/partials/form_field.html" with field=form.manager_name %}
         {% include "oscar/dashboard/partials/form_field.html" with field=form.phone %}
@@ -64,7 +66,7 @@
     <div class="table-header">
         <h3>{% trans "Address" %}</h3>
     </div>
-    <div class="card card-body">
+    <div class="card card-body bg-light">
         {% block address_fields %}
         {% with formset=inlines.1 %}
             {{ formset.management_form }}
@@ -88,7 +90,7 @@
     <div class="table-header">
         <h3>{% trans "Location" %}</h3>
     </div>
-    <div class="card card-body">
+    <div class="card card-body bg-light">
         {% block location_fields %}
         <p>
             {% blocktrans %}
@@ -111,7 +113,7 @@
         <h3>{% trans "Opening hours" %}</h3>
     </div>
 
-    <div class="card card-body form-horizontal" id="opening_hours_form">
+    <div class="card card-body bg-light form-horizontal" id="opening_hours_form">
         {% block opening_hours_fields %}
         {# use the first formset which is the opening times #}
         {% with workhours=inlines.0 %}
@@ -195,9 +197,9 @@
     {% block extra_field_blocks %}
     {% endblock extra_field_blocks %}
 
-    <div class="card card-body">
+    <div class="card card-body bg-light">
         <div class="form-actions">
-            <button class="btn btn-primary btn-lg" type="submit">{% trans "Save" %}</button>
+            <button class="btn btn-primary" type="submit">{% trans "Save" %}</button>
             {% trans "or" %}
             <a href="{% url 'stores-dashboard:store-list' %}">{% trans "cancel" %}</a>
         </div>


### PR DESCRIPTION
- remove use of deprecated "django.utils.encoding.force_text"
- remove setting of widget for non-existent "name" field in
  "OpeningPeriodForm" dashboard form
- remove redundant setting of "required" attribute on fields in
  "OpeningPeriodForm" dashboard form
- add ".bg-light" to ".card-body" "div"s in templates
- remove ".btn-sm" and ".btn-lg" from ".btn"s in templates
- use "fa-plus-circle" instead of "fa-plus" in templates, for
  consistency with "django-oscar"
- replace dropped Bootstrap ".label" with ".badge" in templates
- use HTML line breaks for multi-line "stores.StoreAddress.street" data
  in store-list template
- fix markup for row actions dropdown in store-list template
- fix "cancel" URL in store-delete template
- remove unused sub-header "div" in store-group-list template